### PR TITLE
Catch ProcessFailedException

### DIFF
--- a/src/run.php
+++ b/src/run.php
@@ -13,6 +13,7 @@ use Monolog\Handler\ErrorLogHandler;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 
 $logger = new Logger('app-errors', [new ErrorLogHandler]);
 
@@ -56,6 +57,9 @@ try {
     exit(1);
 } catch (AuthenticationException $e) {
     echo $e->getMessage();
+    exit(1);
+} catch (ProcessFailedException $e) {
+    // we do not print exception's message here, it can contain sensitive information
     exit(1);
 } catch (InvalidConfigurationException $e) {
     echo $e->getMessage() . '. Please check connection settings.';


### PR DESCRIPTION
Fixes #56 

Changes:

- Catch `ProcessFailedException` and convert it to user error

Because in most cases, the problem with `mongoexport` command is due to wrong credentials, replicaset setup, etc. - client's side.

Also, exception message is hidden, because its format looks like this:

```
The command "mongoexport --host '127.0.0.1' --port '27017' --db 'test' --collection 'test' --type 'json' --out '/code/data/out/tables/test.json'" failed.

Exit Code: 1(General error)

Working directory: /code

Output:
================


Error Output:
================
```

Which can contain sensitive data.