### PR TITLE
Catch all csvmap exceptions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.0
+FROM php:7.0.29
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927 \

--- a/src/run.php
+++ b/src/run.php
@@ -3,7 +3,7 @@
 require __DIR__ . '/../vendor/autoload.php';
 require __DIR__ . '/common.php';
 
-use Keboola\CsvMap\Exception\BadDataException;
+use Keboola\CsvMap\Exception\CsvMapperException;
 use Keboola\MongoDbExtractor\Application;
 use Keboola\MongoDbExtractor\UserException;
 use MongoDB\Driver\Exception\AuthenticationException;
@@ -68,7 +68,7 @@ try {
 } catch (InvalidConfigurationException $e) {
     echo $e->getMessage() . '. Please check connection settings.';
     exit(1);
-} catch (BadDataException $e) {
+} catch (CsvMapperException $e) {
     echo $e->getMessage()
         . '. Please check mapping section.';
     exit(1);

--- a/tests/Keboola/MongoDbExtractor/ExtractorTestCase.php
+++ b/tests/Keboola/MongoDbExtractor/ExtractorTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Keboola\MongoDbExtractor;
 
+use Keboola\CsvMap\Exception\BadConfigException;
 use Keboola\CsvMap\Exception\BadDataException;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -240,16 +241,38 @@ CSV;
         $export = $extractor->extract($this->path);
     }
 
-    public function testExportInvalidMapping()
+    public function testExportInvalidMappingBadData()
     {
         $this->expectException(BadDataException::class);
         $this->expectExceptionMessage('Error writing \'id\' column: Cannot write object into a column');
 
         $exportParams = [
             'collection' => 'restaurants',
-            'name' => 'export-bad-query',
+            'name' => 'export-bad-mapping',
             'mapping' => [
                 '_id' => 'id' // _id is object
+            ],
+            'enabled' => true,
+            'mode' => 'mapping',
+        ];
+
+        $parameters = $this->getConfig()['parameters'];
+        $parameters['exports'][] = $exportParams;
+
+        $extractor = new Extractor($parameters);
+        $extractor->extract($this->path);
+    }
+
+    public function testExportInvalidMappingBadConfig()
+    {
+        $this->expectException(BadConfigException::class);
+        $this->expectExceptionMessage('Key \'mapping.destination\' is not set for column \'2\'');
+
+        $exportParams = [
+            'collection' => 'restaurants',
+            'name' => 'export-bad-mapping',
+            'mapping' => [
+                '2' => []
             ],
             'enabled' => true,
             'mode' => 'mapping',


### PR DESCRIPTION
Fixes #77 

Changes:

- freeze php to specific version (there's problem with gnupg missing in latest versions)
- catch all csvmap exceptions