### PR TITLE
dont write empty $item

### DIFF
--- a/src/Keboola/MongoDbExtractor/Parser/Raw.php
+++ b/src/Keboola/MongoDbExtractor/Parser/Raw.php
@@ -46,7 +46,7 @@ class Raw
     {
         $item = reset($data);
 
-        if (!empty($data)) {
+        if (!empty($data) && !empty($item)) {
             $this->writerRowToOutputFile($item);
         }
     }


### PR DESCRIPTION
fixes #92 

Snaha o naivny fix tohto bugu ktory reportoval klient, tak to skusam ci by mohlo zabrat.

v chybe sa pise `writerRowToOutputFile() must be an object, null given` tak som urobil len to aby nezapisoval writerRowToOutputFile(null)