### PR TITLE
Accept authSource (authenticationDatabase)

### DIFF
--- a/docker/mongodb/init-auth.js
+++ b/docker/mongodb/init-auth.js
@@ -21,3 +21,15 @@ db.createUser({
         }
     ]
 });
+
+use authDb;
+db.createUser({
+    user: 'userInAuthDb',
+    pwd: 'p#a!s@sw:o&r%^d',
+    roles: [
+        {
+            role: "readWrite",
+            db: "test"
+        }
+    ]
+});

--- a/src/Keboola/MongoDbExtractor/ConfigDefinition.php
+++ b/src/Keboola/MongoDbExtractor/ConfigDefinition.php
@@ -31,6 +31,7 @@ class ConfigDefinition implements ConfigurationInterface
                             ->isRequired()
                             ->cannotBeEmpty()
                         ->end()
+                        ->scalarNode('authDb')->end()
                         ->scalarNode('user')->end()
                         ->scalarNode('password')->end()
                         ->scalarNode('#password')->end()

--- a/src/Keboola/MongoDbExtractor/ConfigDefinition.php
+++ b/src/Keboola/MongoDbExtractor/ConfigDefinition.php
@@ -31,7 +31,7 @@ class ConfigDefinition implements ConfigurationInterface
                             ->isRequired()
                             ->cannotBeEmpty()
                         ->end()
-                        ->scalarNode('authDb')->end()
+                        ->scalarNode('authenticationDatabase')->end()
                         ->scalarNode('user')->end()
                         ->scalarNode('password')->end()
                         ->scalarNode('#password')->end()

--- a/src/Keboola/MongoDbExtractor/Extractor.php
+++ b/src/Keboola/MongoDbExtractor/Extractor.php
@@ -74,6 +74,12 @@ class Extractor
 
         $uri[] = $params['host'] .':' . $params['port'] . '/' . $params['db'];
 
+        if (isset($params['username'], $params['password'], $params['authDb'])
+            && !empty(trim((string) $params['authDb']))
+        ) {
+            $uri[] = '?authSource=' . $params['authDb'];
+        }
+
         $manager = new Manager(implode('', $uri));
 
         return $manager;

--- a/src/Keboola/MongoDbExtractor/Extractor.php
+++ b/src/Keboola/MongoDbExtractor/Extractor.php
@@ -74,10 +74,10 @@ class Extractor
 
         $uri[] = $params['host'] .':' . $params['port'] . '/' . $params['db'];
 
-        if (isset($params['username'], $params['password'], $params['authDb'])
-            && !empty(trim((string) $params['authDb']))
+        if (isset($params['username'], $params['password'], $params['authenticationDatabase'])
+            && !empty(trim((string) $params['authenticationDatabase']))
         ) {
-            $uri[] = '?authSource=' . $params['authDb'];
+            $uri[] = '?authSource=' . $params['authenticationDatabase'];
         }
 
         $manager = new Manager(implode('', $uri));

--- a/src/Keboola/MongoDbExtractor/MongoExportCommandJson.php
+++ b/src/Keboola/MongoDbExtractor/MongoExportCommandJson.php
@@ -81,8 +81,10 @@ class MongoExportCommandJson
             $command[] = '--password ' . escapeshellarg($this->options['password']);
         }
 
-        if (isset($this->options['authDb']) && !empty(trim((string) $this->options['authDb']))) {
-            $command[] = '--authenticationDatabase ' . escapeshellarg($this->options['authDb']);
+        if (isset($this->options['authenticationDatabase'])
+            && !empty(trim((string) $this->options['authenticationDatabase']))
+        ) {
+            $command[] = '--authenticationDatabase ' . escapeshellarg($this->options['authenticationDatabase']);
         }
 
         // export options

--- a/src/Keboola/MongoDbExtractor/MongoExportCommandJson.php
+++ b/src/Keboola/MongoDbExtractor/MongoExportCommandJson.php
@@ -81,6 +81,10 @@ class MongoExportCommandJson
             $command[] = '--password ' . escapeshellarg($this->options['password']);
         }
 
+        if (isset($this->options['authDb'])) {
+            $command[] = '--authenticationDatabase ' . escapeshellarg($this->options['authDb']);
+        }
+
         // export options
         $command[] = '--db ' . escapeshellarg($this->options['db']);
         $command[] = '--collection ' . escapeshellarg($this->options['collection']);

--- a/src/Keboola/MongoDbExtractor/MongoExportCommandJson.php
+++ b/src/Keboola/MongoDbExtractor/MongoExportCommandJson.php
@@ -81,7 +81,7 @@ class MongoExportCommandJson
             $command[] = '--password ' . escapeshellarg($this->options['password']);
         }
 
-        if (isset($this->options['authDb'])) {
+        if (isset($this->options['authDb']) && !empty(trim((string) $this->options['authDb']))) {
             $command[] = '--authenticationDatabase ' . escapeshellarg($this->options['authDb']);
         }
 

--- a/tests/Keboola/MongoDbExtractor/ApplicationTestConnectionTest.php
+++ b/tests/Keboola/MongoDbExtractor/ApplicationTestConnectionTest.php
@@ -51,7 +51,7 @@ JSON;
       "host": "mongodb-auth",
       "port": 27017,
       "database": "test",
-      "authDb": "authDb",
+      "authenticationDatabase": "authDb",
       "user": "userInAuthDb",
       "#password": "p#a!s@sw:o&r%^d"
     },

--- a/tests/Keboola/MongoDbExtractor/ApplicationTestConnectionTest.php
+++ b/tests/Keboola/MongoDbExtractor/ApplicationTestConnectionTest.php
@@ -42,6 +42,41 @@ JSON;
         $this->assertSame(['status' => 'ok'], $application->actionTestConnection());
     }
 
+    public function testActionTestConnectionOkViaAuthDb()
+    {
+        $json = <<<JSON
+{
+  "parameters": {
+    "db": {
+      "host": "mongodb-auth",
+      "port": 27017,
+      "database": "test",
+      "authDb": "authDb",
+      "user": "userInAuthDb",
+      "#password": "p#a!s@sw:o&r%^d"
+    },
+    "exports": [
+      {
+        "name": "bakeries",
+        "id": 123,
+        "collection": "restaurants",
+        "incremental": true,
+        "mapping": {
+          "_id.\$oid": "id"
+        }
+      }
+    ]
+  }
+}
+JSON;
+        $config = (new JsonDecode(true))->decode($json, JsonEncoder::FORMAT);
+
+        $application = new Application($config);
+        $application->actionTestConnection();
+
+        $this->assertSame(['status' => 'ok'], $application->actionTestConnection());
+    }
+
     public function testActionTestConnectionFailWrongHost()
     {
         $this->expectException(ConnectionTimeoutException::class);

--- a/tests/Keboola/MongoDbExtractor/ExtractorDirectConnectionWithAuthDbTest.php
+++ b/tests/Keboola/MongoDbExtractor/ExtractorDirectConnectionWithAuthDbTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Keboola\MongoDbExtractor;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Serializer\Encoder\JsonDecode;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+
+class ExtractorDirectConnectionWithAuthDbTest extends ExtractorTestCase
+{
+    /** @var Filesystem */
+    private $fs;
+
+    protected $path = '/tmp/extractor-direct-auth-db';
+
+    protected function setUp()
+    {
+        $this->fs = new Filesystem;
+        $this->fs->remove($this->path);
+        $this->fs->mkdir($this->path);
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        $this->fs->remove($this->path);
+    }
+
+    protected function getConfig()
+    {
+        $config = <<<JSON
+{
+  "parameters": {
+    "db": {
+      "host": "mongodb-auth",
+      "port": 27017,
+      "database": "test",
+      "authDb": "authDb",
+      "user": "userInAuthDb",
+      "#password": "p#a!s@sw:o&r%^d"
+    }
+  }
+}
+JSON;
+        return (new JsonDecode(true))->decode($config, JsonEncoder::FORMAT);
+    }
+}

--- a/tests/Keboola/MongoDbExtractor/ExtractorDirectConnectionWithAuthDbTest.php
+++ b/tests/Keboola/MongoDbExtractor/ExtractorDirectConnectionWithAuthDbTest.php
@@ -36,7 +36,7 @@ class ExtractorDirectConnectionWithAuthDbTest extends ExtractorTestCase
       "host": "mongodb-auth",
       "port": 27017,
       "database": "test",
-      "authDb": "authDb",
+      "authenticationDatabase": "authDb",
       "user": "userInAuthDb",
       "#password": "p#a!s@sw:o&r%^d"
     }

--- a/tests/Keboola/MongoDbExtractor/ExtractorSshConnectionWithAuthDbTest.php
+++ b/tests/Keboola/MongoDbExtractor/ExtractorSshConnectionWithAuthDbTest.php
@@ -40,7 +40,7 @@ class ExtractorSshConnectionWithAuthDbTest extends ExtractorTestCase
       "host": "mongodb-auth-behind-ssh",
       "port": 27017,
       "database": "test",
-      "authDb": "authDb",
+      "authenticationDatabase": "authDb",
       "user": "userInAuthDb",
       "password": "p#a!s@sw:o&r%^d",
       "ssh": {

--- a/tests/Keboola/MongoDbExtractor/ExtractorSshConnectionWithAuthDbTest.php
+++ b/tests/Keboola/MongoDbExtractor/ExtractorSshConnectionWithAuthDbTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Keboola\MongoDbExtractor;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Serializer\Encoder\JsonDecode;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+
+class ExtractorSshConnectionWithAuthDbTest extends ExtractorTestCase
+{
+    /** @var Filesystem */
+    private $fs;
+
+    protected $path = '/tmp/extractor-ssh-auth';
+
+    protected function setUp()
+    {
+        $this->fs = new Filesystem;
+        $this->fs->remove($this->path);
+        $this->fs->mkdir($this->path);
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        $this->fs->remove($this->path);
+
+        $process = new Process('pgrep ssh | xargs kill');
+        $process->mustRun();
+    }
+
+    protected function getConfig()
+    {
+        $config = <<<JSON
+{
+  "parameters": {
+    "db": {
+      "host": "mongodb-auth-behind-ssh",
+      "port": 27017,
+      "database": "test",
+      "authDb": "authDb",
+      "user": "userInAuthDb",
+      "password": "p#a!s@sw:o&r%^d",
+      "ssh": {
+        "enabled": true,
+        "sshHost": "ssh-tunnel-for-auth",
+        "sshPort": 22,
+        "user": "root",
+        "keys": {
+          "public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvzAADEmS+fqf2YoClcSQJOAhkS5O5AFV18vLpMb8gVuI7Hjb\/XPhsK9uX3mkTTRc6DlvCrl9gfILQ53YrmfmzEIq8FWW4i+R8ZaI4gchh4+QYuvMO7Q2Rgz+WhZsknGLQy2TJ5TkHvtZwagaUxYYmOFvZpwQwWIsQysL1jCYbGknLKJR39WM8rhs5Yk4Y3cMtLw4KGQ35WsFGrSrLuxajlnB8Ob+uMWvMwa8QRjE3adw3rZnjYIgzWiToQU9rDPkAZndUvPUDRJcCqnZw5iceDhPXtOv2b0W+bwrT3xxQVVTTVBnNF9om11hfitpSvJ2YBgTdLr7tvjh+RdW3Zl+t root@6eb3e87c2533",
+          "private": "-----BEGIN RSA PRIVATE KEY-----\\nMIIEpAIBAAKCAQEAr8wAAxJkvn6n9mKApXEkCTgIZEuTuQBVdfLy6TG\/IFbiOx42\\n\/1z4bCvbl95pE00XOg5bwq5fYHyC0Od2K5n5sxCKvBVluIvkfGWiOIHIYePkGLrz\\nDu0NkYM\/loWbJJxi0MtkyeU5B77WcGoGlMWGJjhb2acEMFiLEMrC9YwmGxpJyyiU\\nd\/VjPK4bOWJOGN3DLS8OChkN+VrBRq0qy7sWo5ZwfDm\/rjFrzMGvEEYxN2ncN62Z\\n42CIM1ok6EFPawz5AGZ3VLz1A0SXAqp2cOYnHg4T17Tr9m9Fvm8K098cUFVU01QZ\\nzRfaJtdYX4raUrydmAYE3S6+7b44fkXVt2ZfrQIDAQABAoIBAFvGnoL8CUhCCyHf\\nztWQOYXukML7icVdXUBUc2g2plcVxMmkPoYWXULrqpqgbC69YlDWyiTar8RJfGnf\\nTJv6qJdJHYSPjylHLyOaU5Q4fQpN1PjsMJQsQZcj9AB7A8GbOyNR6+5TEvDuOjk5\\nwPHOJPizF5CLVu5+ayt7D0jtv78Jnigx3urk2IlhxdnnaiO2pdPDdWROMaKmsRh+\\nsClo982lM3\/eTjAKNiqTFnTsX8eZ8OL2wg1cqX4C0BCRhs5E4TZq\/biteHKbxnx8\\nibz6NqW5GDsE0wGBrnfXpXe+g2pqOn+0kBvQrWCK7kEYth7dpLO6Q19vJhyBL2iC\\ndXtDRcECgYEA5YTHbyzkvOmTjfWGc2dCO7w4vVgK4n\/UowZ49Qm9O9if5e7d+g0f\\ng0G84um\/OIRUB74QxioF9E9CPreKvLAbYR0cl743d\/MYvN\/WR88gPDqPt61tzUpf\\nJqC\/oLqUrif7MRTudgW\/iOuXa+rnwUcXwzpWvQyT+4ttrF9HQK+\/aakCgYEAxBR1\\nDib1B30Am997Ra62pf73iJ7BCuPvWfNoNQnrDMzPp4+DzU2vHD1uxO\/9aUssRfXG\\n3ryzV23H2lAggzLQE4+TK0vp8A0DGF87wC58Zirzn4zP4aTUdS5es0ud8HKfzuE6\\nDJaRwfNun1AOakL\/+dOJ9yhiGHXomojHy\/PCMGUCgYEA1dmklOLIcXhU4nU9A\/PX\\nE59pYopRAf9HGWrjcrTTW5qYSX4J1304umya2PYgFEG\/pcMjD\/CBwcPDnnoXS33u\\n1MpyJLS4LAwWJY2NszS6\/UM3O1XdM+UyyOQICHMwKyDXfEDbep4aezG\/0W5652wd\\nKOsHfHfmvf6Ifo377rqR55kCgYAn\/iAt5cY+Y8GXCUsEWHFKhCmKxQ6MoRb1ms7b\\nWo2Fi9Si0YPJgRnBQcpxAp4GNt3t2wZX8dcGcw67OXKYL+n+w176Cr7JRm4mL25p\\ncVHQKNyN41OXK15mFDIekcLCAy8TLB8B6EgMbhFXDyYRiF7bXskaDzOK16m8sz9F\\nGw+1fQKBgQDZ7TrtZR2cuYutZMbkkM6HQHWSWjfU1azVJretjDzTJdqPUUJvGmLM\\nOU6QjfNCKYTpx0Iy\/zRarjLtuAhF0rbLbbxcdppMKgMrTHXypR+1jOeOawi3yplL\\n3JfqZK0CHz6QZ+Uj2I3aMkcliDGk4VYDwl\/boEuHVeFPM3lodS0y8w==\\n-----END RSA PRIVATE KEY-----\\n"
+        }
+      }
+    }
+  }
+}
+JSON;
+        return (new JsonDecode(true))->decode($config, JsonEncoder::FORMAT);
+    }
+}

--- a/tests/Keboola/MongoDbExtractor/Unit/MongoExportCommandJsonTest.php
+++ b/tests/Keboola/MongoDbExtractor/Unit/MongoExportCommandJsonTest.php
@@ -25,6 +25,28 @@ BASH;
         $this->assertSame($expectedCommand, $command->getCommand());
     }
 
+    public function testWithCustomAuthenticationDatabase()
+    {
+        $options = [
+            'host' => 'localhost',
+            'port' => 27017,
+            'db' => 'myDatabase',
+            'collection' => 'myCollection',
+            'out' => '/tmp/create-test.json',
+            // auth with custom auth database
+            'username' => 'user',
+            'password' => 'pass',
+            'authDb' => 'myAuthDatabase',
+        ];
+
+        $command = new MongoExportCommandJson($options);
+        $expectedCommand = <<<BASH
+mongoexport --host 'localhost' --port '27017' --username 'user' --password 'pass' --authenticationDatabase 'myAuthDatabase' --db 'myDatabase' --collection 'myCollection' --type 'json' --out '/tmp/create-test.json'
+BASH;
+
+        $this->assertSame($expectedCommand, $command->getCommand());
+    }
+
     public function testCreateFull()
     {
         $options = [

--- a/tests/Keboola/MongoDbExtractor/Unit/MongoExportCommandJsonTest.php
+++ b/tests/Keboola/MongoDbExtractor/Unit/MongoExportCommandJsonTest.php
@@ -36,7 +36,7 @@ BASH;
             // auth with custom auth database
             'username' => 'user',
             'password' => 'pass',
-            'authDb' => 'myAuthDatabase',
+            'authenticationDatabase' => 'myAuthDatabase',
         ];
 
         $command = new MongoExportCommandJson($options);
@@ -58,7 +58,7 @@ BASH;
             // auth with empty custom auth database
             'username' => 'user',
             'password' => 'pass',
-            'authDb' => ' ',
+            'authenticationDatabase' => ' ',
         ];
 
         $command = new MongoExportCommandJson($options);

--- a/tests/Keboola/MongoDbExtractor/Unit/MongoExportCommandJsonTest.php
+++ b/tests/Keboola/MongoDbExtractor/Unit/MongoExportCommandJsonTest.php
@@ -47,6 +47,28 @@ BASH;
         $this->assertSame($expectedCommand, $command->getCommand());
     }
 
+    public function testWithEmptyCustomAuthenticationDatabase()
+    {
+        $options = [
+            'host' => 'localhost',
+            'port' => 27017,
+            'db' => 'myDatabase',
+            'collection' => 'myCollection',
+            'out' => '/tmp/create-test.json',
+            // auth with empty custom auth database
+            'username' => 'user',
+            'password' => 'pass',
+            'authDb' => ' ',
+        ];
+
+        $command = new MongoExportCommandJson($options);
+        $expectedCommand = <<<BASH
+mongoexport --host 'localhost' --port '27017' --username 'user' --password 'pass' --db 'myDatabase' --collection 'myCollection' --type 'json' --out '/tmp/create-test.json'
+BASH;
+
+        $this->assertSame($expectedCommand, $command->getCommand());
+    }
+
     public function testCreateFull()
     {
         $options = [


### PR DESCRIPTION
Fixes: #97 

Changes:

- Add test user to other database and test authentication against it
- Accept `authDb` param in config definition
- Pass `authDb` param to export command as `--authenticationDatabase` if specified
- Pass `authDb` to connection uri as `authSource` when specified
- Tests, tests, tests

