### PR TITLE
Support for 'mongodb+src' protocol for cluster connection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY docker/php/php-prod.ini /usr/local/etc/php/php.ini
 COPY docker/composer-install.sh /tmp/composer-install.sh
 
 RUN apt-get update -q \
-  && apt-get install unzip git libssl-dev ssh gnupg2 dirmngr wget -y --no-install-recommends \
+  && apt-get install unzip git libssl-dev ssh gnupg2 dirmngr wget wait-for-it -y --no-install-recommends \
   && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4 \
   && echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/4.0 main" > /etc/apt/sources.list.d/mongodb-org-4.0.list \
   && apt-get update -q \

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "require-dev": {
         "phpunit/phpunit": "^7.2",
         "squizlabs/php_codesniffer": "^3.3",
-        "keboola/coding-standard": "^4.0"
+        "keboola/coding-standard": "^4.0",
+        "mockery/mockery": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a9467ac61d9f2f0a178f15376bf6926",
+    "content-hash": "5995fdcea142cc5875e037fd4159e824",
     "packages": [
         {
             "name": "keboola/csv",
@@ -1024,6 +1024,54 @@
             "time": "2017-07-22T11:58:36+00:00"
         },
         {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "1.3.3",
+                "phpunit/phpunit": "~4.0",
+                "satooshi/php-coveralls": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "time": "2016-01-20T08:20:44+00:00"
+        },
+        {
             "name": "keboola/coding-standard",
             "version": "4.0.0",
             "source": {
@@ -1048,6 +1096,71 @@
             ],
             "description": "Keboola coding standard",
             "time": "2018-05-15T15:09:36+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be",
+                "reference": "f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "~2.0",
+                "lib-pcre": ">=7.0",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.7.10|~6.5|~7.0|~8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "time": "2019-12-26T09:49:15+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,16 +12,22 @@ services:
       - ssh-tunnel
       - mongodb-auth
       - ssh-tunnel-for-auth
+      - node1.mongodb.cluster.local
+      - dns.local
     command: >
-             sh -c '
-             sleep 6
-             && mongoimport --host mongodb --db test --collection restaurants --drop --file tests/dataset.json
-             && mongoimport --host mongodb --db test --collection restaurantsIdAsString --drop --file tests/dataset-id-as-string.json
-             && mongoimport --host mongodb --db test --collection invalidJSON --drop --file tests/dataset-invalid-json-values.json
-             && mongoimport --host mongodb --db test --collection mixedIds --drop --file tests/dataset-mixed-ids.json
-             && mongoimport --host mongodb-auth --username user --password "p#a!s@sw:o&r%^d" --db test --collection restaurants --drop --file tests/dataset.json
-             && bash
-             '
+      sh -c '
+      php -r "echo \"nameserver \" . gethostbyname(\"dns.local\") . \"\n\";" > /etc/resolv.conf.new
+      && cp /etc/resolv.conf /etc/resolv.conf.bak
+      && cp /etc/resolv.conf.new /etc/resolv.conf
+      && sleep 10
+      && mongoimport --host mongodb --db test --collection restaurants --drop --file tests/dataset.json
+      && mongoimport --host mongodb --db test --collection restaurantsIdAsString --drop --file tests/dataset-id-as-string.json
+      && mongoimport --host mongodb --db test --collection invalidJSON --drop --file tests/dataset-invalid-json-values.json
+      && mongoimport --host mongodb --db test --collection mixedIds --drop --file tests/dataset-mixed-ids.json
+      && mongoimport --host mongodb-auth --username user --password "p#a!s@sw:o&r%^d" --db test --collection restaurants --drop --file tests/dataset.json
+      && mongoimport --host node1.mongodb.cluster.local --db test --collection restaurants --drop --file tests/dataset.json
+      && bash
+      '
     volumes:
       - ./:/code
       - ./docker/php/php.ini:/usr/local/etc/php/php.ini
@@ -35,16 +41,22 @@ services:
       - ssh-tunnel
       - mongodb-auth
       - ssh-tunnel-for-auth
+      - node1.mongodb.cluster.local
+      - dns.local
     command: >
-             sh -c '
-             sleep 6
-             && mongoimport --host mongodb --db test --collection restaurants --drop --file tests/dataset.json
-             && mongoimport --host mongodb --db test --collection restaurantsIdAsString --drop --file tests/dataset-id-as-string.json
-             && mongoimport --host mongodb --db test --collection invalidJSON --drop --file tests/dataset-invalid-json-values.json
-             && mongoimport --host mongodb --db test --collection mixedIds --drop --file tests/dataset-mixed-ids.json
-             && mongoimport --host mongodb-auth --username user --password "p#a!s@sw:o&r%^d" --db test --collection restaurants --drop --file tests/dataset.json
-             && ./tests.sh
-             '
+      sh -c '
+      php -r "echo \"nameserver \" . gethostbyname(\"dns.local\") . \"\n\";" > /etc/resolv.conf.new
+      && cp /etc/resolv.conf /etc/resolv.conf.bak
+      && cp /etc/resolv.conf.new /etc/resolv.conf
+      && sleep 10
+      && mongoimport --host mongodb --db test --collection restaurants --drop --file tests/dataset.json
+      && mongoimport --host mongodb --db test --collection restaurantsIdAsString --drop --file tests/dataset-id-as-string.json
+      && mongoimport --host mongodb --db test --collection invalidJSON --drop --file tests/dataset-invalid-json-values.json
+      && mongoimport --host mongodb --db test --collection mixedIds --drop --file tests/dataset-mixed-ids.json
+      && mongoimport --host mongodb-auth --username user --password "p#a!s@sw:o&r%^d" --db test --collection restaurants --drop --file tests/dataset.json
+      && mongoimport --host node1.mongodb.cluster.local --db test --collection restaurants --drop --file tests/dataset.json
+      && ./tests.sh
+      '
     volumes:
       - ./docker/php/php.ini:/usr/local/etc/php/php.ini
 
@@ -57,26 +69,50 @@ services:
       - ssh-tunnel
       - mongodb-auth
       - ssh-tunnel-for-auth
+      - node1.mongodb.cluster.local
+      - dns.local
     command: >-
-             sh -c '
-             sleep 6
-             && mongoimport --host mongodb --db test --collection restaurants --drop --file tests/dataset.json
-             && mongoimport --host mongodb --db test --collection restaurantsIdAsString --drop --file tests/dataset-id-as-string.json
-             && mongoimport --host mongodb --db test --collection invalidJSON --drop --file tests/dataset-invalid-json-values.json
-             && mongoimport --host mongodb --db test --collection mixedIds --drop --file tests/dataset-mixed-ids.json
-             && mongoimport --host mongodb-auth --username user --password "p#a!s@sw:o&r%^d" --db test --collection restaurants --drop --file tests/dataset.json
-             && curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-             && chmod +x ./cc-test-reporter
-             && ./cc-test-reporter before-build
-             && ./tests.sh
-             && ./cc-test-reporter after-build
-             '
+      sh -c '
+      php -r "echo \"nameserver \" . gethostbyname(\"dns.local\") . \"\n\";" > /etc/resolv.conf.new
+      && cp /etc/resolv.conf /etc/resolv.conf.bak
+      && cp /etc/resolv.conf.new /etc/resolv.conf
+      && sleep 10
+      && mongoimport --host mongodb --db test --collection restaurants --drop --file tests/dataset.json
+      && mongoimport --host mongodb --db test --collection restaurantsIdAsString --drop --file tests/dataset-id-as-string.json
+      && mongoimport --host mongodb --db test --collection invalidJSON --drop --file tests/dataset-invalid-json-values.json
+      && mongoimport --host mongodb --db test --collection mixedIds --drop --file tests/dataset-mixed-ids.json
+      && mongoimport --host mongodb-auth --username user --password "p#a!s@sw:o&r%^d" --db test --collection restaurants --drop --file tests/dataset.json
+      && mongoimport --host node1.mongodb.cluster.local --db test --collection restaurants --drop --file tests/dataset.json
+      && curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+      && chmod +x ./cc-test-reporter
+      && ./cc-test-reporter before-build
+      && ./tests.sh
+      && ./cc-test-reporter after-build
+      '
     volumes:
       - ./.git:/code/.git
       - ./docker/php/php.ini:/usr/local/etc/php/php.ini
 
+  # DNS server for testing mongodb+srv:// connection
+  # https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format
+  dns.local:
+    image: jpillora/dnsmasq
+    entrypoint: >
+      dnsmasq
+        --conf-file=''
+        --resolv-file=/etc/resolv.conf
+        --no-daemon
+        --log-queries
+        --log-facility=-
+        --srv-host '_mongodb._tcp.mongodb.cluster.local,node1.mongodb.cluster.local,27017'
+        --txt-record 'mongodb.cluster.local'
+
   mongodb:
     image: mongo:3.2
+
+  node1.mongodb.cluster.local:
+    image: mongo:4.2
+    command: mongod
 
   mongodb-auth:
     extends:
@@ -84,13 +120,13 @@ services:
     volumes:
       - ./docker/mongodb/init-auth.js:/init.js
     command: >
-             sh -c '
-             sh -c "mongod &"
-             && sleep 2
-             && mongo < /init.js
-             && mongod --shutdown
-             && mongod --auth
-             '
+      sh -c '
+      sh -c "mongod &"
+      && sleep 2
+      && mongo < /init.js
+      && mongod --shutdown
+      && mongod --auth
+      '
 
   ssh-tunnel:
     image: quay.io/keboola/mongodb-extractor-ssh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: "2"
 
 services:
-
   php:
     build: .
     image: keboola/mongodb-extractor
@@ -14,20 +13,25 @@ services:
       - ssh-tunnel-for-auth
       - node1.mongodb.cluster.local
       - dns.local
-    command: >
-      sh -c '
-      php -r "echo \"nameserver \" . gethostbyname(\"dns.local\") . \"\n\";" > /etc/resolv.conf.new
-      && cp /etc/resolv.conf /etc/resolv.conf.bak
-      && cp /etc/resolv.conf.new /etc/resolv.conf
-      && sleep 10
-      && mongoimport --host mongodb --db test --collection restaurants --drop --file tests/dataset.json
-      && mongoimport --host mongodb --db test --collection restaurantsIdAsString --drop --file tests/dataset-id-as-string.json
-      && mongoimport --host mongodb --db test --collection invalidJSON --drop --file tests/dataset-invalid-json-values.json
-      && mongoimport --host mongodb --db test --collection mixedIds --drop --file tests/dataset-mixed-ids.json
-      && mongoimport --host mongodb-auth --username user --password "p#a!s@sw:o&r%^d" --db test --collection restaurants --drop --file tests/dataset.json
-      && mongoimport --host node1.mongodb.cluster.local --db test --collection restaurants --drop --file tests/dataset.json
-      && bash
-      '
+    entrypoint: &phpInit
+      - sh
+      - -c
+      - >
+        php -r "echo \"nameserver \" . gethostbyname(\"dns.local\") . \"\n\";" > /etc/resolv.conf.new
+        && cp /etc/resolv.conf /etc/resolv.conf.bak
+        && cp /etc/resolv.conf.new /etc/resolv.conf
+        && wait-for-it -t 100 mongodb:27017
+        && wait-for-it -t 100 mongodb-auth:27017
+        && wait-for-it -t 100 node1.mongodb.cluster.local:27017
+        && mongoimport --host mongodb --db test --collection restaurants --drop --file tests/dataset.json
+        && mongoimport --host mongodb --db test --collection restaurantsIdAsString --drop --file tests/dataset-id-as-string.json
+        && mongoimport --host mongodb --db test --collection invalidJSON --drop --file tests/dataset-invalid-json-values.json
+        && mongoimport --host mongodb --db test --collection mixedIds --drop --file tests/dataset-mixed-ids.json
+        && mongoimport --host mongodb-auth --username user --password "p#a!s@sw:o&r%^d" --db test --collection restaurants --drop --file tests/dataset.json
+        && mongoimport --host node1.mongodb.cluster.local --db test --collection restaurants --drop --file tests/dataset.json
+        && exec "$$@"
+      - sh
+    command: bash
     volumes:
       - ./:/code
       - ./docker/php/php.ini:/usr/local/etc/php/php.ini
@@ -43,20 +47,8 @@ services:
       - ssh-tunnel-for-auth
       - node1.mongodb.cluster.local
       - dns.local
-    command: >
-      sh -c '
-      php -r "echo \"nameserver \" . gethostbyname(\"dns.local\") . \"\n\";" > /etc/resolv.conf.new
-      && cp /etc/resolv.conf /etc/resolv.conf.bak
-      && cp /etc/resolv.conf.new /etc/resolv.conf
-      && sleep 10
-      && mongoimport --host mongodb --db test --collection restaurants --drop --file tests/dataset.json
-      && mongoimport --host mongodb --db test --collection restaurantsIdAsString --drop --file tests/dataset-id-as-string.json
-      && mongoimport --host mongodb --db test --collection invalidJSON --drop --file tests/dataset-invalid-json-values.json
-      && mongoimport --host mongodb --db test --collection mixedIds --drop --file tests/dataset-mixed-ids.json
-      && mongoimport --host mongodb-auth --username user --password "p#a!s@sw:o&r%^d" --db test --collection restaurants --drop --file tests/dataset.json
-      && mongoimport --host node1.mongodb.cluster.local --db test --collection restaurants --drop --file tests/dataset.json
-      && ./tests.sh
-      '
+    entrypoint: *phpInit
+    command: ./tests.sh
     volumes:
       - ./docker/php/php.ini:/usr/local/etc/php/php.ini
 
@@ -71,19 +63,10 @@ services:
       - ssh-tunnel-for-auth
       - node1.mongodb.cluster.local
       - dns.local
+    entrypoint: *phpInit
     command: >-
       sh -c '
-      php -r "echo \"nameserver \" . gethostbyname(\"dns.local\") . \"\n\";" > /etc/resolv.conf.new
-      && cp /etc/resolv.conf /etc/resolv.conf.bak
-      && cp /etc/resolv.conf.new /etc/resolv.conf
-      && sleep 10
-      && mongoimport --host mongodb --db test --collection restaurants --drop --file tests/dataset.json
-      && mongoimport --host mongodb --db test --collection restaurantsIdAsString --drop --file tests/dataset-id-as-string.json
-      && mongoimport --host mongodb --db test --collection invalidJSON --drop --file tests/dataset-invalid-json-values.json
-      && mongoimport --host mongodb --db test --collection mixedIds --drop --file tests/dataset-mixed-ids.json
-      && mongoimport --host mongodb-auth --username user --password "p#a!s@sw:o&r%^d" --db test --collection restaurants --drop --file tests/dataset.json
-      && mongoimport --host node1.mongodb.cluster.local --db test --collection restaurants --drop --file tests/dataset.json
-      && curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+      curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
       && chmod +x ./cc-test-reporter
       && ./cc-test-reporter before-build
       && ./tests.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
         && wait-for-it -t 100 mongodb:27017
         && wait-for-it -t 100 mongodb-auth:27017
         && wait-for-it -t 100 node1.mongodb.cluster.local:27017
+        && sleep 1
         && mongoimport --host mongodb --db test --collection restaurants --drop --file tests/dataset.json
         && mongoimport --host mongodb --db test --collection restaurantsIdAsString --drop --file tests/dataset-id-as-string.json
         && mongoimport --host mongodb --db test --collection invalidJSON --drop --file tests/dataset-invalid-json-values.json

--- a/src/Keboola/MongoDbExtractor/Application.php
+++ b/src/Keboola/MongoDbExtractor/Application.php
@@ -15,6 +15,9 @@ class Application
     /** @var array */
     private $parameters;
 
+    /** @var Extractor */
+    private $extractor;
+
     public function __construct(array $config)
     {
         $this->config = $config;
@@ -26,6 +29,10 @@ class Application
             !== count(array_unique(array_column($this->parameters['exports'], 'name')))) {
             throw new UserException('Please remove duplicate export names');
         }
+
+        $uriFactory = new UriFactory();
+        $exportCommandFactory = new ExportCommandFactory($uriFactory);
+        $this->extractor = new Extractor($uriFactory, $exportCommandFactory, $this->parameters);
     }
 
     /**
@@ -36,8 +43,7 @@ class Application
      */
     public function actionRun(string $outputPath): bool
     {
-        $extractor = new Extractor($this->parameters);
-        return $extractor->extract($outputPath);
+        return $this->extractor->extract($outputPath);
     }
 
     /**
@@ -46,8 +52,7 @@ class Application
      */
     public function actionTestConnection(): array
     {
-        $extractor = new Extractor($this->parameters);
-        $extractor->testConnection();
+        $this->extractor->testConnection();
         return [
             'status' => 'ok',
         ];

--- a/src/Keboola/MongoDbExtractor/Config/ConfigDefinition.php
+++ b/src/Keboola/MongoDbExtractor/Config/ConfigDefinition.php
@@ -10,6 +10,11 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 
 class ConfigDefinition implements ConfigurationInterface
 {
+    public const
+        PROTOCOL_MONGO_DB = 'mongodb',
+        PROTOCOL_MONGO_DB_SRV = 'mongodb+srv'; // https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format
+
+
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder();
@@ -19,6 +24,10 @@ class ConfigDefinition implements ConfigurationInterface
             ->children()
                 ->arrayNode('db')
                     ->children()
+                        ->enumNode('protocol')
+                            ->values([self::PROTOCOL_MONGO_DB, self::PROTOCOL_MONGO_DB_SRV])
+                            ->defaultValue(self::PROTOCOL_MONGO_DB)
+                        ->end()
                         ->scalarNode('host')
                             ->isRequired()
                             ->cannotBeEmpty()

--- a/src/Keboola/MongoDbExtractor/Config/ConfigDefinition.php
+++ b/src/Keboola/MongoDbExtractor/Config/ConfigDefinition.php
@@ -33,7 +33,6 @@ class ConfigDefinition implements ConfigurationInterface
                             ->cannotBeEmpty()
                         ->end()
                         ->scalarNode('port')
-                            ->isRequired()
                             ->cannotBeEmpty()
                         ->end()
                         ->scalarNode('database')

--- a/src/Keboola/MongoDbExtractor/Export.php
+++ b/src/Keboola/MongoDbExtractor/Export.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\MongoDbExtractor;
 
-use Keboola\MongoDbExtractor\ExportCommandFactory;
 use Keboola\MongoDbExtractor\Parser\Mapping;
 use Keboola\MongoDbExtractor\Parser\Raw;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -17,6 +16,9 @@ use Symfony\Component\Serializer\Exception\NotEncodableValueException;
 
 class Export
 {
+    /** @var ExportCommandFactory */
+    private $exportCommandFactory;
+
     /** @var array */
     private $connectionOptions;
 
@@ -42,6 +44,7 @@ class Export
     private $jsonDecoder;
 
     public function __construct(
+        ExportCommandFactory $exportCommandFactory,
         array $connectionOptions,
         array $exportOptions,
         string $path,
@@ -53,6 +56,7 @@ class Export
             throw new UserException('Mapping cannot be empty in "mapping" export mode.');
         }
 
+        $this->exportCommandFactory = $exportCommandFactory;
         $this->connectionOptions = $connectionOptions;
         $this->exportOptions = $exportOptions;
         $this->path = $path;
@@ -74,8 +78,7 @@ class Export
             ['out' => $this->getOutputFilename()]
         );
 
-        $factory = new ExportCommandFactory();
-        $cliCommand = $factory->create($options);
+        $cliCommand = $this->exportCommandFactory->create($options);
 
         $process = new Process($cliCommand, null, null, null, null);
         $process->mustRun(function ($type, $buffer): void {

--- a/src/Keboola/MongoDbExtractor/ExportCommandFactory.php
+++ b/src/Keboola/MongoDbExtractor/ExportCommandFactory.php
@@ -33,8 +33,8 @@ class ExportCommandFactory
             $command[] = '--port ' . escapeshellarg((string) $params['port']);
             $command[] = '--db ' . escapeshellarg($params['database']);
 
-            if (isset($params['username'])) {
-                $command[] = '--username ' . escapeshellarg($params['username']);
+            if (isset($params['user'])) {
+                $command[] = '--username ' . escapeshellarg($params['user']);
                 $command[] = '--password ' . escapeshellarg($params['password']);
             }
 

--- a/src/Keboola/MongoDbExtractor/ExportCommandFactory.php
+++ b/src/Keboola/MongoDbExtractor/ExportCommandFactory.php
@@ -28,7 +28,12 @@ class ExportCommandFactory
             $command[] = '--uri ' . escapeshellarg($uri);
         } else {
             // If not mongodb+srv://, then use standard parameters: --host, --db, ...
-            // because --uri parameter does not work well with the SSH tunnel (probably a bug)
+            // because --uri parameter does not work well with some MongoDB servers (probably a bug).
+            // In that case:
+            // .... test Connection through PHP driver works OK
+            // .... mongoexport with --host parameter works OK
+            // .... mongoexport with --uri parameter freezes without writing an error
+            // Therefore is --uri parameter used only with mongodb+srv://, where there is no other way.
             $command[] = '--host ' . escapeshellarg($params['host']);
             $command[] = '--port ' . escapeshellarg((string) $params['port']);
             $command[] = '--db ' . escapeshellarg($params['database']);

--- a/src/Keboola/MongoDbExtractor/ExportCommandFactory.php
+++ b/src/Keboola/MongoDbExtractor/ExportCommandFactory.php
@@ -4,26 +4,45 @@ declare(strict_types=1);
 
 namespace Keboola\MongoDbExtractor;
 
+use Keboola\MongoDbExtractor\Config\ConfigDefinition;
+
 class ExportCommandFactory
 {
+    /** @var UriFactory */
+    private $uriFactory;
+
+    public function __construct(UriFactory $uriFactory)
+    {
+        $this->uriFactory = $uriFactory;
+    }
+
     public function create(array $params): string
     {
+        $protocol = $params['protocol'] ?? ConfigDefinition::PROTOCOL_MONGO_DB;
         $command = ['mongoexport'];
 
         // Connection options
-        $command[] = '--host ' . escapeshellarg($params['host']);
-        $command[] = '--port ' . escapeshellarg((string) $params['port']);
-        $command[] = '--db ' . escapeshellarg($params['database']);
+        if ($protocol === ConfigDefinition::PROTOCOL_MONGO_DB_SRV) {
+            // mongodb+srv:// can be used only in URI parameter
+            $uri = $this->uriFactory->create($params);
+            $command[] = '--uri ' . escapeshellarg($uri);
+        } else {
+            // If not mongodb+srv://, then use standard parameters: --host, --db, ...
+            // because --uri parameter does not work well with the SSH tunnel (probably a bug)
+            $command[] = '--host ' . escapeshellarg($params['host']);
+            $command[] = '--port ' . escapeshellarg((string) $params['port']);
+            $command[] = '--db ' . escapeshellarg($params['database']);
 
-        if (isset($params['username'])) {
-            $command[] = '--username ' . escapeshellarg($params['username']);
-            $command[] = '--password ' . escapeshellarg($params['password']);
-        }
+            if (isset($params['username'])) {
+                $command[] = '--username ' . escapeshellarg($params['username']);
+                $command[] = '--password ' . escapeshellarg($params['password']);
+            }
 
-        if (isset($params['authenticationDatabase'])
-            && !empty(trim((string) $params['authenticationDatabase']))
-        ) {
-            $command[] = '--authenticationDatabase ' . escapeshellarg($params['authenticationDatabase']);
+            if (isset($params['authenticationDatabase'])
+                && !empty(trim((string) $params['authenticationDatabase']))
+            ) {
+                $command[] = '--authenticationDatabase ' . escapeshellarg($params['authenticationDatabase']);
+            }
         }
 
         // Export options

--- a/src/Keboola/MongoDbExtractor/Extractor.php
+++ b/src/Keboola/MongoDbExtractor/Extractor.php
@@ -42,12 +42,12 @@ class Extractor
 
         $dbParams = $this->parameters['db'];
 
-        // Port is required
+        // Host is required
         if (empty($dbParams['host'])) {
             throw new UserException('Missing connection parameter "host".');
         }
 
-        // Db is required
+        // Database is required
         if (empty($dbParams['database'])) {
             throw new UserException('Missing connection parameter "db".');
         }

--- a/src/Keboola/MongoDbExtractor/Extractor.php
+++ b/src/Keboola/MongoDbExtractor/Extractor.php
@@ -21,13 +21,10 @@ class Extractor
 
     /**
      * Mapping:
-     * - compatibility with db-extractor-common
      * - encrypted password
      * @var array
      */
     private $dbParamsMapping = [
-        'user' => 'username',
-        'database' => 'db',
         '#password' => 'password',
     ];
 
@@ -51,13 +48,13 @@ class Extractor
         }
 
         // Db is required
-        if (empty($dbParams['db'])) {
+        if (empty($dbParams['database'])) {
             throw new UserException('Missing connection parameter "db".');
         }
 
         // validate auth options: both or none
-        if (isset($dbParams['username']) && !isset($dbParams['password'])
-            || !isset($dbParams['username']) && isset($dbParams['password'])) {
+        if (isset($dbParams['user']) && !isset($dbParams['password'])
+            || !isset($dbParams['user']) && isset($dbParams['password'])) {
             throw new UserException('When passing authentication details,'
                 . ' both "user" and "password" params are required');
         }

--- a/src/Keboola/MongoDbExtractor/UriFactory.php
+++ b/src/Keboola/MongoDbExtractor/UriFactory.php
@@ -13,8 +13,8 @@ class UriFactory
         $protocol = $params['protocol']  ?? ConfigDefinition::PROTOCOL_MONGO_DB;
         $uri = [$protocol . '://'];
 
-        if (isset($params['username'], $params['password'])) {
-            $uri[] = rawurlencode($params['username']) . ':' . rawurlencode($params['password']) . '@';
+        if (isset($params['user'], $params['password'])) {
+            $uri[] = rawurlencode($params['user']) . ':' . rawurlencode($params['password']) . '@';
         }
 
         $uri[] = $params['host'];
@@ -31,7 +31,7 @@ class UriFactory
 
         $uri[] = '/' . $params['database'];
 
-        if (isset($params['username'], $params['password'], $params['authenticationDatabase'])
+        if (isset($params['user'], $params['password'], $params['authenticationDatabase'])
             && !empty(trim((string) $params['authenticationDatabase']))
         ) {
             $uri[] = '?authSource=' . $params['authenticationDatabase'];

--- a/src/Keboola/MongoDbExtractor/UriFactory.php
+++ b/src/Keboola/MongoDbExtractor/UriFactory.php
@@ -4,17 +4,25 @@ declare(strict_types=1);
 
 namespace Keboola\MongoDbExtractor;
 
+use Keboola\MongoDbExtractor\Config\ConfigDefinition;
+
 class UriFactory
 {
     public function create(array $params): string
     {
-        $uri = ['mongodb://'];
+        $protocol = $params['protocol']  ?? ConfigDefinition::PROTOCOL_MONGO_DB;
+        $uri = [$protocol . '://'];
 
         if (isset($params['username'], $params['password'])) {
             $uri[] = rawurlencode($params['username']) . ':' . rawurlencode($params['password']) . '@';
         }
 
-        $uri[] = $params['host'] .':' . $params['port'] . '/' . $params['db'];
+        $uri[] = $params['host'];
+
+        // URI starting with mongodb+srv:// must not include a port number
+        $uri[] = $protocol === ConfigDefinition::PROTOCOL_MONGO_DB_SRV ? '' : (':' . $params['port']);
+
+        $uri[] = '/' . $params['db'];
 
         if (isset($params['username'], $params['password'], $params['authenticationDatabase'])
             && !empty(trim((string) $params['authenticationDatabase']))

--- a/src/Keboola/MongoDbExtractor/UriFactory.php
+++ b/src/Keboola/MongoDbExtractor/UriFactory.php
@@ -19,10 +19,17 @@ class UriFactory
 
         $uri[] = $params['host'];
 
+        // Validate port, required for mongodb://, optional/ignored for mongodb+srv://
         // URI starting with mongodb+srv:// must not include a port number
-        $uri[] = $protocol === ConfigDefinition::PROTOCOL_MONGO_DB_SRV ? '' : (':' . $params['port']);
+        if ($protocol === ConfigDefinition::PROTOCOL_MONGO_DB) {
+            if (empty($params['port'])) {
+                throw new UserException('Missing connection parameter "port".');
+            }
 
-        $uri[] = '/' . $params['db'];
+            $uri[] = ':' . $params['port'];
+        }
+
+        $uri[] = '/' . $params['database'];
 
         if (isset($params['username'], $params['password'], $params['authenticationDatabase'])
             && !empty(trim((string) $params['authenticationDatabase']))

--- a/tests/Keboola/MongoDbExtractor/ApplicationTest.php
+++ b/tests/Keboola/MongoDbExtractor/ApplicationTest.php
@@ -3,6 +3,7 @@
 namespace Keboola\MongoDbExtractor;
 
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Process\Process;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Filesystem\Filesystem;

--- a/tests/Keboola/MongoDbExtractor/ConfigDefinitionTest.php
+++ b/tests/Keboola/MongoDbExtractor/ConfigDefinitionTest.php
@@ -93,8 +93,7 @@ JSON;
 {
   "parameters": {
     "db": {
-      "host": "127.0.0.1",
-      "database": "test"
+      "host": "127.0.0.1"
     },
     "exports": [
       {

--- a/tests/Keboola/MongoDbExtractor/ConfigDefinitionTest.php
+++ b/tests/Keboola/MongoDbExtractor/ConfigDefinitionTest.php
@@ -43,9 +43,49 @@ JSON;
         $processedConfig = $processor->processConfiguration(new ConfigDefinition, [$config['parameters']]);
 
         $this->assertInternalType('array', $processedConfig);
+
+        // Protocol key is optional, test default value
+        $this->assertSame(ConfigDefinition::PROTOCOL_MONGO_DB, $processedConfig['db']['protocol']);
     }
 
-    public function testInvalidConfig()
+    public function testValidConfigWithProtocol()
+    {
+        $json = <<<JSON
+{
+  "parameters": {
+    "db": {
+      "protocol": "mongodb+srv",
+      "host": "127.0.0.1",
+      "port": 27017,
+      "database": "test",
+      "user": "user",
+      "password": "password"
+    },
+    "exports": [
+      {
+        "name": "bronx-bakeries",
+        "id": 123,
+        "collection": "restaurants",
+        "query": "{borough: \"Bronx\"}",
+        "incremental": false,
+        "mapping": {
+          "_id": null
+        }
+      }
+    ]
+  }
+}
+JSON;
+
+        $config = (new JsonDecode(true))->decode($json, JsonEncoder::FORMAT);
+        $processor = new Processor;
+        $processedConfig = $processor->processConfiguration(new ConfigDefinition, [$config['parameters']]);
+
+        $this->assertInternalType('array', $processedConfig);
+        $this->assertSame(ConfigDefinition::PROTOCOL_MONGO_DB_SRV, $processedConfig['db']['protocol']);
+    }
+
+    public function testMissingKeys()
     {
         $this->expectException(InvalidConfigurationException::class);
 
@@ -69,4 +109,41 @@ JSON;
         $config = (new JsonDecode(true))->decode($json, JsonEncoder::FORMAT);
         (new Processor())->processConfiguration(new ConfigDefinition, [$config['parameters']]);
     }
+
+    public function testInvalidProtocol()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        $json = <<<JSON
+{
+  "parameters": {
+    "db": {
+      "protocol": "mongodb+error",
+      "host": "127.0.0.1",
+      "port": 27017,
+      "database": "test",
+      "user": "user",
+      "password": "password"
+    },
+    "exports": [
+      {
+        "name": "bronx-bakeries",
+        "id": 123,
+        "collection": "restaurants",
+        "query": "{borough: \"Bronx\"}",
+        "incremental": false,
+        "mapping": {
+          "_id": null
+        }
+      }
+    ]
+  }
+}
+JSON;
+
+        $config = (new JsonDecode(true))->decode($json, JsonEncoder::FORMAT);
+        (new Processor())->processConfiguration(new ConfigDefinition, [$config['parameters']]);
+    }
+
+
 }

--- a/tests/Keboola/MongoDbExtractor/ExtractorClusterConnectionTest.php
+++ b/tests/Keboola/MongoDbExtractor/ExtractorClusterConnectionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Keboola\MongoDbExtractor;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Serializer\Encoder\JsonDecode;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+
+/**
+ * Test connection using mongodb+srv:// URI prefix
+ * See: https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format
+ */
+class ExtractorClusterConnectionTest extends ExtractorTestCase
+{
+    /** @var Filesystem */
+    private $fs;
+
+    protected $path = '/tmp/extractor-direct';
+
+    protected function setUp()
+    {
+        $this->fs = new Filesystem;
+        $this->fs->remove($this->path);
+        $this->fs->mkdir($this->path);
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        $this->fs->remove($this->path);
+    }
+
+    protected function getConfig()
+    {
+        $config = <<<JSON
+{
+  "parameters": {
+    "db": {
+      "protocol": "mongodb+srv",
+      "host": "",
+      "port": 27017,
+      "database": "test",
+      "user": "test",
+      "#password": ""
+    }
+  }
+}
+JSON;
+        return (new JsonDecode(true))->decode($config, JsonEncoder::FORMAT);
+    }
+}

--- a/tests/Keboola/MongoDbExtractor/ExtractorNoSpaceLeftOnDeviceTest.php
+++ b/tests/Keboola/MongoDbExtractor/ExtractorNoSpaceLeftOnDeviceTest.php
@@ -9,11 +9,21 @@ use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
 class ExtractorNoSpaceLeftOnDeviceTest extends \PHPUnit\Framework\TestCase
 {
+    use CreateExtractorTrait;
+
+    /** @var UriFactory */
+    protected $uriFactory;
+
+    /** @var ExportCommandFactory */
+    protected $exportCommandFactory;
+
     /** @var Filesystem */
     private $fs;
 
+    /** @var string */
     private $path = '/tmp/no-space-left-on-device';
 
+    /** @var string */
     private $file = 'export-one.csv';
 
     protected function setUp()
@@ -25,6 +35,9 @@ class ExtractorNoSpaceLeftOnDeviceTest extends \PHPUnit\Framework\TestCase
         // simulate full disk
         $process = new Process('ln -s /dev/full ' . $this->path . '/' . $this->file);
         $process->mustRun();
+
+        $this->uriFactory = new UriFactory();
+        $this->exportCommandFactory = new ExportCommandFactory($this->uriFactory);
     }
 
     public function testExportNoSpaceLeftOnDevice()
@@ -42,9 +55,7 @@ class ExtractorNoSpaceLeftOnDeviceTest extends \PHPUnit\Framework\TestCase
 
         $parameters = $this->getConfig()['parameters'];
         $parameters['exports'][] = $exportParams;
-
-        $extractor = new Extractor($parameters);
-        $extractor->extract($this->path);
+        $this->createExtractor($parameters)->extract($this->path);
     }
 
     protected function getConfig()

--- a/tests/Keboola/MongoDbExtractor/ExtractorNotEnabledExportsTest.php
+++ b/tests/Keboola/MongoDbExtractor/ExtractorNotEnabledExportsTest.php
@@ -7,10 +7,21 @@ use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
 class ExtractorNotEnabledExportsTest extends \PHPUnit\Framework\TestCase
 {
+    use CreateExtractorTrait;
+
+    /** @var string */
     protected $path = '/tmp/extractor-not-enabled-exports';
+
+    /** @var UriFactory */
+    protected $uriFactory;
+
+    /** @var ExportCommandFactory */
+    protected $exportCommandFactory;
 
     protected function setUp()
     {
+        $this->uriFactory = new UriFactory();
+        $this->exportCommandFactory = new ExportCommandFactory($this->uriFactory);
     }
 
     protected function getConfig()
@@ -46,8 +57,6 @@ JSON;
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Please enable at least one export');
-
-        $extractor = new Extractor($this->getConfig()['parameters']);
-        $extractor->extract($this->path);
+        $this->createExtractor($this->getConfig()['parameters'])->extract($this->path);
     }
 }

--- a/tests/Keboola/MongoDbExtractor/ExtractorObjectInPrimaryKeyTest.php
+++ b/tests/Keboola/MongoDbExtractor/ExtractorObjectInPrimaryKeyTest.php
@@ -9,6 +9,14 @@ use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
 class ExtractorObjectInPrimaryKeyTest extends \PHPUnit\Framework\TestCase
 {
+    use CreateExtractorTrait;
+
+    /** @var UriFactory */
+    protected $uriFactory;
+
+    /** @var ExportCommandFactory */
+    protected $exportCommandFactory;
+
     /** @var Filesystem */
     private $fs;
 
@@ -16,6 +24,9 @@ class ExtractorObjectInPrimaryKeyTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
+        $this->uriFactory = new UriFactory();
+        $this->exportCommandFactory = new ExportCommandFactory($this->uriFactory);
+
         $this->fs = new Filesystem;
         $this->fs->remove($this->path);
         $this->fs->mkdir($this->path);
@@ -25,11 +36,7 @@ class ExtractorObjectInPrimaryKeyTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(BadConfigException::class);
         $this->expectExceptionMessageRegExp('~Only scalar values are allowed in primary key.~');
-
-        $parameters = $this->getConfig()['parameters'];
-
-        $extractor = new Extractor($parameters);
-        $extractor->extract($this->path);
+        $this->createExtractor($this->getConfig()['parameters'])->extract($this->path);
     }
 
     protected function getConfig()

--- a/tests/Keboola/MongoDbExtractor/ExtractorSshConnectionTimeoutTest.php
+++ b/tests/Keboola/MongoDbExtractor/ExtractorSshConnectionTimeoutTest.php
@@ -10,12 +10,25 @@ use Keboola\SSHTunnel\SSHException;
 
 class ExtractorSshConnectionTimeoutTest extends \PHPUnit\Framework\TestCase
 {
-    private $fs;
+    use CreateExtractorTrait;
 
+    /** @var UriFactory */
+    protected $uriFactory;
+
+    /** @var ExportCommandFactory */
+    protected $exportCommandFactory;
+
+    /** @var string */
     protected $path = '/tmp/extractor-ssh-connection-timeout';
+
+    /** @var Filesystem */
+    private $fs;
 
     protected function setUp()
     {
+        $this->uriFactory = new UriFactory();
+        $this->exportCommandFactory = new ExportCommandFactory($this->uriFactory);
+
         $this->fs = new Filesystem;
         $this->fs->remove($this->path);
         $this->fs->mkdir($this->path);
@@ -75,7 +88,7 @@ JSON;
         $this->expectException(SSHException::class);
         $this->expectExceptionMessage('Unable to create ssh tunnel');
 
-        new Extractor($this->getConfig()['parameters']);
+        $this->createExtractor($this->getConfig()['parameters']);
         // we don't call extract, so it'll end with SshException for sure
     }
 }

--- a/tests/Keboola/MongoDbExtractor/ExtractorTestCase.php
+++ b/tests/Keboola/MongoDbExtractor/ExtractorTestCase.php
@@ -9,10 +9,21 @@ use Symfony\Component\Process\Process;
 
 abstract class ExtractorTestCase extends \PHPUnit\Framework\TestCase
 {
+    use CreateExtractorTrait;
+
+    /** @var string */
     protected $path;
+
+    /** @var UriFactory */
+    protected $uriFactory;
+
+    /** @var ExportCommandFactory */
+    protected $exportCommandFactory;
 
     protected function setUp()
     {
+        $this->uriFactory = new UriFactory();
+        $this->exportCommandFactory = new ExportCommandFactory($this->uriFactory);
     }
 
     abstract protected function getConfig();
@@ -48,7 +59,7 @@ abstract class ExtractorTestCase extends \PHPUnit\Framework\TestCase
         $parameters = $this->getConfig()['parameters'];
         $parameters['exports'][] = $exportParams;
 
-        $extractor = new Extractor($parameters);
+        $extractor = $this->createExtractor($parameters);
         $export = $extractor->extract($this->path);
 
         $this->assertTrue($export, 'Command successful');
@@ -76,7 +87,7 @@ abstract class ExtractorTestCase extends \PHPUnit\Framework\TestCase
         $parameters = $this->getConfig()['parameters'];
         $parameters['exports'][] = $exportParams;
 
-        $extractor = new Extractor($parameters);
+        $extractor = $this->createExtractor($parameters);
         $export = $extractor->extract($this->path);
 
         $this->assertTrue($export, 'Command successful');
@@ -105,7 +116,7 @@ CSV;
         $parameters = $this->getConfig()['parameters'];
         $parameters['exports'][] = $exportParams;
 
-        $extractor = new Extractor($parameters);
+        $extractor = $this->createExtractor($parameters);
         $export = $extractor->extract($this->path);
 
         $this->assertTrue($export, 'Command successful');
@@ -134,7 +145,7 @@ CSV;
         $parameters = $this->getConfig()['parameters'];
         $parameters['exports'][] = $exportParams;
 
-        $extractor = new Extractor($parameters);
+        $extractor = $this->createExtractor($parameters);
         $export = $extractor->extract($this->path);
 
         $this->assertTrue($export, 'Command successful');
@@ -166,7 +177,7 @@ CSV;
         $parameters = $this->getConfig()['parameters'];
         $parameters['exports'][] = $exportParams;
 
-        $extractor = new Extractor($parameters);
+        $extractor = $this->createExtractor($parameters);
         $export = $extractor->extract($this->path);
 
         $this->assertTrue($export, 'Command successful');
@@ -200,7 +211,7 @@ CSV;
         $parameters = $this->getConfig()['parameters'];
         $parameters['exports'][] = $exportParams;
 
-        $extractor = new Extractor($parameters);
+        $extractor = $this->createExtractor($parameters);
         $export = $extractor->extract($this->path);
 
         $this->assertTrue($export, 'Command successful');
@@ -234,7 +245,7 @@ CSV;
         $parameters = $this->getConfig()['parameters'];
         $parameters['exports'][] = $exportParams;
 
-        $extractor = new Extractor($parameters);
+        $extractor = $this->createExtractor($parameters);
         $extractor->extract($this->path);
     }
 
@@ -256,7 +267,7 @@ CSV;
         $parameters = $this->getConfig()['parameters'];
         $parameters['exports'][] = $exportParams;
 
-        $extractor = new Extractor($parameters);
+        $extractor = $this->createExtractor($parameters);
         $extractor->extract($this->path);
     }
 
@@ -278,7 +289,7 @@ CSV;
         $parameters = $this->getConfig()['parameters'];
         $parameters['exports'][] = $exportParams;
 
-        $extractor = new Extractor($parameters);
+        $extractor = $this->createExtractor($parameters);
         $extractor->extract($this->path);
     }
 
@@ -296,7 +307,7 @@ CSV;
         $parameters = $this->getConfig()['parameters'];
         $parameters['exports'][] = $exportParams;
 
-        $extractor = new Extractor($parameters);
+        $extractor = $this->createExtractor($parameters);
         $export = $extractor->extract($this->path);
 
         $this->assertTrue($export, 'Command successful');
@@ -354,7 +365,7 @@ JSON
         $parameters = $this->getConfig()['parameters'];
         $parameters['exports'][] = $exportParams;
 
-        $extractor = new Extractor($parameters);
+        $extractor = $this->createExtractor($parameters);
         $export = $extractor->extract($this->path);
 
         $this->assertTrue($export, 'Command successful');

--- a/tests/Keboola/MongoDbExtractor/Traits/CreateExtractorTrait.php
+++ b/tests/Keboola/MongoDbExtractor/Traits/CreateExtractorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Keboola\MongoDbExtractor;
+
+trait CreateExtractorTrait
+{
+    /** @var UriFactory */
+    protected $uriFactory;
+
+    /** @var ExportCommandFactory */
+    protected $exportCommandFactory;
+
+    public function createExtractor(array $parameters): Extractor
+    {
+        return new Extractor($this->uriFactory, $this->exportCommandFactory, $parameters);
+    }
+}

--- a/tests/Keboola/MongoDbExtractor/Unit/ExportCommandFactoryTest.php
+++ b/tests/Keboola/MongoDbExtractor/Unit/ExportCommandFactoryTest.php
@@ -119,6 +119,28 @@ BASH;
         $this->assertSame($expectedCommand, $command);
     }
 
+    public function testMongoDbSrvProtocolWithCustomAuthenticationDatabase()
+    {
+        $options = [
+            'protocol' => 'mongodb+srv',
+            'host' => 'localhost',
+            'port' => 123456,
+            'database' => 'myDatabase',
+            'collection' => 'myCollection',
+            'out' => '/tmp/create-test.json',
+            'user' => 'user',
+            'password' => 'pass',
+            'authenticationDatabase' => 'myAuthDatabase',
+        ];
+
+        $command = $this->commandFactory->create($options);
+
+        $expectedCommand = <<<BASH
+mongoexport --uri 'mongodb+srv://user:pass@localhost/myDatabase?authSource=myAuthDatabase' --collection 'myCollection' --type 'json' --out '/tmp/create-test.json'
+BASH;
+        $this->assertSame($expectedCommand, $command);
+    }
+
     public function testWithEmptyCustomAuthenticationDatabase()
     {
         $options = [

--- a/tests/Keboola/MongoDbExtractor/Unit/ExportCommandFactoryTest.php
+++ b/tests/Keboola/MongoDbExtractor/Unit/ExportCommandFactoryTest.php
@@ -106,7 +106,7 @@ BASH;
             'collection' => 'myCollection',
             'out' => '/tmp/create-test.json',
             // auth with custom auth database
-            'username' => 'user',
+            'user' => 'user',
             'password' => 'pass',
             'authenticationDatabase' => 'myAuthDatabase',
         ];
@@ -128,7 +128,7 @@ BASH;
             'collection' => 'myCollection',
             'out' => '/tmp/create-test.json',
             // auth with empty custom auth database
-            'username' => 'user',
+            'user' => 'user',
             'password' => 'pass',
             'authenticationDatabase' => ' ',
         ];
@@ -146,7 +146,7 @@ BASH;
         $options = [
             'host' => 'localhost',
             'port' => 27017,
-            'username' => 'user',
+            'user' => 'user',
             'password' => 'pass',
             'database' => 'myDatabase',
             'collection' => 'myCollection',
@@ -169,7 +169,7 @@ BASH;
         $options = [
             'host' => 'localhost',
             'port' => 27017,
-            'username' => 'user',
+            'user' => 'user',
             'password' => 'pass',
             'database' => 'myDatabase',
             'collection' => 'myCollection',

--- a/tests/Keboola/MongoDbExtractor/Unit/ExportCommandFactoryTest.php
+++ b/tests/Keboola/MongoDbExtractor/Unit/ExportCommandFactoryTest.php
@@ -35,6 +35,46 @@ BASH;
         $this->assertSame($expectedCommand, $command);
     }
 
+    public function testMongoDbProtocol()
+    {
+        $options = [
+            'protocol' => 'mongodb',
+            'host' => 'localhost',
+            'port' => 27017,
+            'db' => 'myDatabase',
+            'collection' => 'myCollection',
+            'out' => '/tmp/create-test.json',
+        ];
+
+        $command = $this->commandFactory->create($options);
+        $expectedCommand = <<<BASH
+mongoexport --uri 'mongodb://localhost:27017/myDatabase' --collection 'myCollection' --type 'json' --out '/tmp/create-test.json'
+BASH;
+
+        $this->assertSame($expectedCommand, $command);
+    }
+
+    public function testMongoDbSrvProtocol()
+    {
+        $options = [
+            'protocol' => 'mongodb+srv',
+            'host' => 'localhost',
+            'port' => 27017,
+            'db' => 'myDatabase',
+            'collection' => 'myCollection',
+            'out' => '/tmp/create-test.json',
+        ];
+
+        $command = $this->commandFactory->create($options);
+
+        // URI starting with mongodb+srv:// must not include a port number
+        $expectedCommand = <<<BASH
+mongoexport --uri 'mongodb+srv://localhost/myDatabase' --collection 'myCollection' --type 'json' --out '/tmp/create-test.json'
+BASH;
+
+        $this->assertSame($expectedCommand, $command);
+    }
+
     public function testWithCustomAuthenticationDatabase()
     {
         $options = [

--- a/tests/Keboola/MongoDbExtractor/Unit/UriFactoryTest.php
+++ b/tests/Keboola/MongoDbExtractor/Unit/UriFactoryTest.php
@@ -21,7 +21,7 @@ class UriFactoryTest extends TestCase
         $this->assertSame('mongodb://localhost:27017/myDatabase', $this->uriFactory->create([
             'host' => 'localhost',
             'port' => 27017,
-            'db' => 'myDatabase',
+            'database' => 'myDatabase',
         ]));
     }
 
@@ -30,7 +30,7 @@ class UriFactoryTest extends TestCase
         $this->assertSame('mongodb://user:pass@localhost:27017/myDatabase', $this->uriFactory->create([
             'host' => 'localhost',
             'port' => 27017,
-            'db' => 'myDatabase',
+            'database' => 'myDatabase',
             'username' => 'user',
             'password' => 'pass',
         ]));
@@ -41,7 +41,7 @@ class UriFactoryTest extends TestCase
         $this->assertSame('mongodb://user:pass@localhost:27017/myDatabase?authSource=authDb', $this->uriFactory->create([
             'host' => 'localhost',
             'port' => 27017,
-            'db' => 'myDatabase',
+            'database' => 'myDatabase',
             'username' => 'user',
             'password' => 'pass',
             'authenticationDatabase' => 'authDb',

--- a/tests/Keboola/MongoDbExtractor/Unit/UriFactoryTest.php
+++ b/tests/Keboola/MongoDbExtractor/Unit/UriFactoryTest.php
@@ -31,7 +31,7 @@ class UriFactoryTest extends TestCase
             'host' => 'localhost',
             'port' => 27017,
             'database' => 'myDatabase',
-            'username' => 'user',
+            'user' => 'user',
             'password' => 'pass',
         ]));
     }
@@ -42,7 +42,7 @@ class UriFactoryTest extends TestCase
             'host' => 'localhost',
             'port' => 27017,
             'database' => 'myDatabase',
-            'username' => 'user',
+            'user' => 'user',
             'password' => 'pass',
             'authenticationDatabase' => 'authDb',
         ]));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,4 +2,5 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 require __DIR__ . '/../src/common.php';
+require __DIR__ . '/Keboola/MongoDbExtractor/Traits/CreateExtractorTrait.php';
 require __DIR__ . '/Keboola/MongoDbExtractor/ExtractorTestCase.php';


### PR DESCRIPTION
Changes:
- add support for `mongodb+srv://` protocol
- add optional `db.protocol` parameter to configuration, value can be `mongodb`(default) or `mongodb+srv`
- code and `docker-compose.yml` cleanup
- replaced `sleep` with `wait-for-it` in testing environment, fix for local testing and random errors