### PR TITLE
Test connection before mongoexport

### DIFF
--- a/src/Keboola/MongoDbExtractor/Extractor.php
+++ b/src/Keboola/MongoDbExtractor/Extractor.php
@@ -50,7 +50,7 @@ class Extractor
             $sshOptions['remoteHost'] = $this->parameters['db']['host'];
             $sshOptions['remotePort'] = $this->parameters['db']['port'];
 
-            $this->createSshTunnel($sshOptions);
+            (new SSH())->openTunnel($sshOptions);
 
             $this->parameters['db']['host'] = '127.0.0.1';
             $this->parameters['db']['port'] = $sshOptions['localPort'];
@@ -99,18 +99,5 @@ class Extractor
         }
 
         return true;
-    }
-
-    private function createSshTunnel(array $sshOptions): void
-    {
-        (new SSH())->openTunnel($sshOptions);
-
-        // Wait for port
-        $timeoutSeconds = 10;
-        $fp = fsockopen('127.0.0.1', (int) $sshOptions['localPort'], $errCode, $errStr, $timeoutSeconds);
-        if (!$fp) {
-            throw new UserException('SSH tunnel timeout.');
-        }
-        fclose($fp);
     }
 }

--- a/src/Keboola/MongoDbExtractor/Extractor.php
+++ b/src/Keboola/MongoDbExtractor/Extractor.php
@@ -50,7 +50,7 @@ class Extractor
             $sshOptions['remoteHost'] = $this->parameters['db']['host'];
             $sshOptions['remotePort'] = $this->parameters['db']['port'];
 
-            (new SSH())->openTunnel($sshOptions);
+            $this->createSshTunnel($sshOptions);
 
             $this->parameters['db']['host'] = '127.0.0.1';
             $this->parameters['db']['port'] = $sshOptions['localPort'];
@@ -76,6 +76,8 @@ class Extractor
      */
     public function extract(string $outputPath): bool
     {
+        $this->testConnection();
+
         $count = 0;
 
         foreach ($this->parameters['exports'] as $exportOptions) {
@@ -99,5 +101,10 @@ class Extractor
         }
 
         return true;
+    }
+
+    private function createSshTunnel(array $sshOptions): void
+    {
+        (new SSH())->openTunnel($sshOptions);
     }
 }


### PR DESCRIPTION
Reason:
- if is local part of SSH tunel (`127.0.0.1:????`) unreachable, an exception is thrown -> it is OK
- if is remote part of SSH tunel unrechable -> `mongoexport` waits without timeout -> it is PROBLEM
- Before refactoring: connection was tested before `mongoexport` -> it was removed, because duplicated

Changes:
- Connection test before `mongoexport` is reverted back
- That prevents before wait without error and timeout of a job