### PR TITLE
Workaround for mongoexport bug, --uri param doesn't work with SSH tunnel

### DIFF
--- a/src/Keboola/MongoDbExtractor/ExportCommandFactory.php
+++ b/src/Keboola/MongoDbExtractor/ExportCommandFactory.php
@@ -4,17 +4,29 @@ declare(strict_types=1);
 
 namespace Keboola\MongoDbExtractor;
 
-use Keboola\MongoDbExtractor\UriFactory;
-
 class ExportCommandFactory
 {
     public function create(array $params): string
     {
-        $uriFactory = new UriFactory();
-        $uri = $uriFactory->create($params);
-
         $command = ['mongoexport'];
-        $command[] = '--uri ' . escapeshellarg($uri);
+
+        // Connection options
+        $command[] = '--host ' . escapeshellarg($params['host']);
+        $command[] = '--port ' . escapeshellarg((string) $params['port']);
+        $command[] = '--db ' . escapeshellarg($params['database']);
+
+        if (isset($params['username'])) {
+            $command[] = '--username ' . escapeshellarg($params['username']);
+            $command[] = '--password ' . escapeshellarg($params['password']);
+        }
+
+        if (isset($params['authenticationDatabase'])
+            && !empty(trim((string) $params['authenticationDatabase']))
+        ) {
+            $command[] = '--authenticationDatabase ' . escapeshellarg($params['authenticationDatabase']);
+        }
+
+        // Export options
         $command[] = '--collection ' . escapeshellarg($params['collection']);
 
         foreach (['query', 'sort', 'limit'] as $option) {

--- a/src/Keboola/MongoDbExtractor/UriFactory.php
+++ b/src/Keboola/MongoDbExtractor/UriFactory.php
@@ -6,29 +6,8 @@ namespace Keboola\MongoDbExtractor;
 
 class UriFactory
 {
-    /** @var array */
-    private $requiredDbOptions = [
-        'host',
-        'port',
-        'db',
-    ];
-
     public function create(array $params): string
     {
-        array_walk($this->requiredDbOptions, function ($option) use ($params): void {
-            if (!isset($params[$option])) {
-                $msg = sprintf('Missing connection parameter "%s".', $option);
-                throw new UserException($msg);
-            }
-        });
-
-        // validate auth options: both or none
-        if (isset($params['username']) && !isset($params['password'])
-            || !isset($params['username']) && isset($params['password'])) {
-            throw new UserException('When passing authentication details,'
-                . ' both "user" and "password" params are required');
-        }
-
         $uri = ['mongodb://'];
 
         if (isset($params['username'], $params['password'])) {

--- a/tests/Keboola/MongoDbExtractor/ApplicationTest.php
+++ b/tests/Keboola/MongoDbExtractor/ApplicationTest.php
@@ -212,6 +212,7 @@ JSON;
     public function testValidateWithoutUser()
     {
         $this->expectException(UserException::class);
+        $this->expectExceptionMessageRegExp('~When passing authentication details, both "user" and "password" params are required~');
 
         $json = <<<JSON
 {
@@ -245,6 +246,7 @@ JSON;
     public function testValidateWithoutPassword()
     {
         $this->expectException(UserException::class);
+        $this->expectExceptionMessageRegExp('~When passing authentication details, both "user" and "password" params are required~');
 
         $json = <<<JSON
 {

--- a/tests/Keboola/MongoDbExtractor/ApplicationTest.php
+++ b/tests/Keboola/MongoDbExtractor/ApplicationTest.php
@@ -2,6 +2,7 @@
 
 namespace Keboola\MongoDbExtractor;
 
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Filesystem\Filesystem;
@@ -202,6 +203,101 @@ JSON;
 }
 JSON;
 
+        $config = (new JsonDecode(true))->decode($json, JsonEncoder::FORMAT);
+
+        $application = new Application($config);
+        $application->actionRun($this->path);
+    }
+
+    public function testValidateWithoutUser()
+    {
+        $this->expectException(UserException::class);
+
+        $json = <<<JSON
+{
+  "parameters": {
+    "db": {
+      "host": "locahost",
+      "password": "password",
+      "port": 27017,
+      "database": "test"
+    },
+    "exports": [
+      {
+        "name": "bakeries",
+        "id": 123,
+        "collection": "restaurants",
+        "incremental": true,
+        "mapping": {
+          "_id.\$oid": "id"
+        }
+      }
+    ]
+  }
+}
+JSON;
+        $config = (new JsonDecode(true))->decode($json, JsonEncoder::FORMAT);
+
+        $application = new Application($config);
+        $application->actionRun($this->path);
+    }
+
+    public function testValidateWithoutPassword()
+    {
+        $this->expectException(UserException::class);
+
+        $json = <<<JSON
+{
+  "parameters": {
+    "db": {
+      "host": "locahost",
+      "user": "user",
+      "port": 27017,
+      "database": "test"
+    },
+    "exports": [
+      {
+        "name": "bakeries",
+        "id": 123,
+        "collection": "restaurants",
+        "incremental": true,
+        "mapping": {
+          "_id.\$oid": "id"
+        }
+      }
+    ]
+  }
+}
+JSON;
+        $config = (new JsonDecode(true))->decode($json, JsonEncoder::FORMAT);
+
+        $application = new Application($config);
+        $application->actionRun($this->path);
+    }
+
+    public function testCreateWithMissingRequiredParam()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessageRegExp('~The child node "host" at path "parameters.db" must be configured~');
+
+        $json = <<<JSON
+{
+  "parameters": {
+    "db": {},
+    "exports": [
+      {
+        "name": "bakeries",
+        "id": 123,
+        "collection": "restaurants",
+        "incremental": true,
+        "mapping": {
+          "_id.\$oid": "id"
+        }
+      }
+    ]
+  }
+}
+JSON;
         $config = (new JsonDecode(true))->decode($json, JsonEncoder::FORMAT);
 
         $application = new Application($config);

--- a/tests/Keboola/MongoDbExtractor/Unit/ExportCommandFactoryTest.php
+++ b/tests/Keboola/MongoDbExtractor/Unit/ExportCommandFactoryTest.php
@@ -22,14 +22,14 @@ class ExportCommandFactoryTest extends TestCase
         $options = [
             'host' => 'localhost',
             'port' => 27017,
-            'db' => 'myDatabase',
+            'database' => 'myDatabase',
             'collection' => 'myCollection',
             'out' => '/tmp/create-test.json',
         ];
 
         $command = $this->commandFactory->create($options);
         $expectedCommand = <<<BASH
-mongoexport --uri 'mongodb://localhost:27017/myDatabase' --collection 'myCollection' --type 'json' --out '/tmp/create-test.json'
+mongoexport --host 'localhost' --port '27017' --db 'myDatabase' --collection 'myCollection' --type 'json' --out '/tmp/create-test.json'
 BASH;
 
         $this->assertSame($expectedCommand, $command);
@@ -40,7 +40,7 @@ BASH;
         $options = [
             'host' => 'localhost',
             'port' => 27017,
-            'db' => 'myDatabase',
+            'database' => 'myDatabase',
             'collection' => 'myCollection',
             'out' => '/tmp/create-test.json',
             // auth with custom auth database
@@ -51,7 +51,7 @@ BASH;
 
         $command = $this->commandFactory->create($options);
         $expectedCommand = <<<BASH
-mongoexport --uri 'mongodb://user:pass@localhost:27017/myDatabase?authSource=myAuthDatabase' --collection 'myCollection' --type 'json' --out '/tmp/create-test.json'
+mongoexport --host 'localhost' --port '27017' --db 'myDatabase' --username 'user' --password 'pass' --authenticationDatabase 'myAuthDatabase' --collection 'myCollection' --type 'json' --out '/tmp/create-test.json'
 BASH;
 
         $this->assertSame($expectedCommand, $command);
@@ -62,7 +62,7 @@ BASH;
         $options = [
             'host' => 'localhost',
             'port' => 27017,
-            'db' => 'myDatabase',
+            'database' => 'myDatabase',
             'collection' => 'myCollection',
             'out' => '/tmp/create-test.json',
             // auth with empty custom auth database
@@ -73,7 +73,7 @@ BASH;
 
         $command = $this->commandFactory->create($options);
         $expectedCommand = <<<BASH
-mongoexport --uri 'mongodb://user:pass@localhost:27017/myDatabase' --collection 'myCollection' --type 'json' --out '/tmp/create-test.json'
+mongoexport --host 'localhost' --port '27017' --db 'myDatabase' --username 'user' --password 'pass' --collection 'myCollection' --type 'json' --out '/tmp/create-test.json'
 BASH;
 
         $this->assertSame($expectedCommand, $command);
@@ -86,7 +86,7 @@ BASH;
             'port' => 27017,
             'username' => 'user',
             'password' => 'pass',
-            'db' => 'myDatabase',
+            'database' => 'myDatabase',
             'collection' => 'myCollection',
             'query' => '{a: "b"}',
             'sort' => '{a: 1, b: -1}',
@@ -96,7 +96,7 @@ BASH;
 
         $command = $this->commandFactory->create($options);
         $expectedCommand = <<<BASH
-mongoexport --uri 'mongodb://user:pass@localhost:27017/myDatabase' --collection 'myCollection' --query '{a: "b"}' --sort '{a: 1, b: -1}' --limit '10' --type 'json' --out '/tmp/create-test.json'
+mongoexport --host 'localhost' --port '27017' --db 'myDatabase' --username 'user' --password 'pass' --collection 'myCollection' --query '{a: "b"}' --sort '{a: 1, b: -1}' --limit '10' --type 'json' --out '/tmp/create-test.json'
 BASH;
 
         $this->assertSame($expectedCommand, $command);
@@ -109,7 +109,7 @@ BASH;
             'port' => 27017,
             'username' => 'user',
             'password' => 'pass',
-            'db' => 'myDatabase',
+            'database' => 'myDatabase',
             'collection' => 'myCollection',
             'query' => '',
             'sort' => ' ',
@@ -119,48 +119,9 @@ BASH;
 
         $command = $this->commandFactory->create($options);
         $expectedCommand = <<<BASH
-mongoexport --uri 'mongodb://user:pass@localhost:27017/myDatabase' --collection 'myCollection' --type 'json' --out '/tmp/create-test.json'
+mongoexport --host 'localhost' --port '27017' --db 'myDatabase' --username 'user' --password 'pass' --collection 'myCollection' --type 'json' --out '/tmp/create-test.json'
 BASH;
 
         $this->assertSame($expectedCommand, $command);
-    }
-
-    public function testValidateWithoutUser()
-    {
-        $this->expectException(UserException::class);
-
-        $options = [
-            'host' => 'localhost',
-            'port' => 27017,
-            'password' => 'password',
-            'db' => 'myDatabase',
-            'collection' => 'myCollection',
-            'out' => '/tmp/validate-test.json',
-        ];
-
-        $this->commandFactory->create($options);
-    }
-
-    public function testValidateWithoutPassword()
-    {
-        $this->expectException(UserException::class);
-
-        $options = [
-            'host' => 'localhost',
-            'port' => 27017,
-            'username' => 'user',
-            'db' => 'myDatabase',
-            'collection' => 'myCollection',
-            'out' => '/tmp/validate-test.json',
-        ];
-
-        $this->commandFactory->create($options);
-    }
-
-    public function testCreateWithMissingRequiredParam()
-    {
-        $this->expectException(UserException::class);
-        $options = [];
-        $this->commandFactory->create($options);
     }
 }

--- a/tests/Keboola/MongoDbExtractor/Unit/UriFactoryTest.php
+++ b/tests/Keboola/MongoDbExtractor/Unit/UriFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Keboola\MongoDbExtractor\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Keboola\MongoDbExtractor\UriFactory;
+
+class UriFactoryTest extends TestCase
+{
+    /** @var UriFactory */
+    private $uriFactory;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->uriFactory = new UriFactory();
+    }
+
+    public function testCreateMinimal()
+    {
+        $this->assertSame('mongodb://localhost:27017/myDatabase', $this->uriFactory->create([
+            'host' => 'localhost',
+            'port' => 27017,
+            'db' => 'myDatabase',
+        ]));
+    }
+
+    public function testCreateUserAndPassword()
+    {
+        $this->assertSame('mongodb://user:pass@localhost:27017/myDatabase', $this->uriFactory->create([
+            'host' => 'localhost',
+            'port' => 27017,
+            'db' => 'myDatabase',
+            'username' => 'user',
+            'password' => 'pass',
+        ]));
+    }
+
+    public function testCreateAuthDb()
+    {
+        $this->assertSame('mongodb://user:pass@localhost:27017/myDatabase?authSource=authDb', $this->uriFactory->create([
+            'host' => 'localhost',
+            'port' => 27017,
+            'db' => 'myDatabase',
+            'username' => 'user',
+            'password' => 'pass',
+            'authenticationDatabase' => 'authDb',
+        ]));
+    }
+}


### PR DESCRIPTION
Changes:
- mongoexport `--uri` parameter replaced with `--host`, `--db`, ...