### PR TITLE
Handle empty string value for "limit"

### DIFF
--- a/src/Keboola/MongoDbExtractor/Export.php
+++ b/src/Keboola/MongoDbExtractor/Export.php
@@ -155,7 +155,8 @@ class Export
      */
     public function getLastFetchedValue()
     {
-        if (isset($this->exportOptions['limit'])) {
+        // Limit can be disabled with empty string
+        if (!empty($this->exportOptions['limit'])) {
             $lastvalueOptions = [
                 'limit' => 1,
                 'skip' => $this->exportOptions['limit']-1,


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-287

Changes:
- An empty string in `limit` no longer causes an error.