### PR TITLE
Fix support for VPN uri, mixed lower/upper case letters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY docker/php/php-prod.ini /usr/local/etc/php/php.ini
 COPY docker/composer-install.sh /tmp/composer-install.sh
 
 RUN apt-get update -q \
-  && apt-get install unzip git libssl-dev ssh gnupg2 dirmngr wget wait-for-it -y --no-install-recommends \
+  && apt-get install unzip git libssl-dev libicu-dev g++ ssh gnupg2 dirmngr wget wait-for-it -y --no-install-recommends \
   && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4 \
   && echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/4.0 main" > /etc/apt/sources.list.d/mongodb-org-4.0.list \
   && apt-get update -q \
@@ -16,6 +16,10 @@ RUN apt-get update -q \
   && /tmp/composer-install.sh \
   && rm /tmp/composer-install.sh \
   && mv composer.phar /usr/local/bin/composer
+
+# Intl is required for league/uri
+RUN docker-php-ext-configure intl \
+    && docker-php-ext-install intl
 
 RUN pecl install mongodb \
   && docker-php-ext-enable mongodb

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "keboola/csvmap": "^0.6.0",
         "php": "^7.4",
         "ext-json": "*",
+        "ext-intl": "*",
         "keboola/csv": "^1.1",
         "league/uri": "^6.2",
         "league/uri-components": "^2.2"

--- a/tests/Keboola/MongoDbExtractor/ExtractorInvalidUriTest.php
+++ b/tests/Keboola/MongoDbExtractor/ExtractorInvalidUriTest.php
@@ -61,8 +61,8 @@ JSON;
     {
         $this->expectException(UserException::class);
         $this->expectExceptionMessage(
-            'Failed to parse MongoDB URI: The host `mongodb://keboola-test@mongodb/test` is invalid : ' .
-            'a registered name can not contain URI delimiters or spaces'
+            'Failed to parse MongoDB URI: ' .
+            "'mongodb://mongodb://keboola-test@mongodb/test:27017/test'. Invalid host string in URI."
         );
         $this->createExtractor($this->getConfig()['parameters'])->extract($this->path);
     }

--- a/tests/Keboola/MongoDbExtractor/Unit/UriFactoryTest.php
+++ b/tests/Keboola/MongoDbExtractor/Unit/UriFactoryTest.php
@@ -91,6 +91,17 @@ class UriFactoryTest extends TestCase
                     'authenticationDatabase' => 'authDb',
                 ],
             ],
+            'vpn-host' => [
+                'mongodb://user:pass@aBC1cmVrABc.vpn2keboola.com:27017/a%2Fb%2Fc%24%25%5E?authSource=authDb',
+                [
+                    'host' => 'aBC1cmVrABc.vpn2keboola.com',
+                    'port' => 27017,
+                    'database' => 'a/b/c$%^',
+                    'user' => 'user',
+                    'password' => 'pass',
+                    'authenticationDatabase' => 'authDb',
+                ],
+            ],
             'mongodb+srv' => [
                 'mongodb+srv://u%24er:pa%24%24@mongodb.cluster.local/myDatabase?authSource=authDb',
                 [
@@ -107,6 +118,14 @@ class UriFactoryTest extends TestCase
                 [
                     'protocol' => 'custom_uri',
                     'uri' => 'mongodb://user%40@localhost:27017/db?authSource=authDb&replicaSet=myRepl',
+                    'password' => 'pas$$word@',
+                ],
+            ],
+            'vpn-custom-uri' => [
+                'mongodb://user%40:pas%24%24word%40@aBC1cmVrABc.vpn2keboola.com/db?authSource=authDb&replicaSet=myRepl',
+                [
+                    'protocol' => 'custom_uri',
+                    'uri' => 'mongodb://user%40@aBC1cmVrABc.vpn2keboola.com/db?authSource=authDb&replicaSet=myRepl',
                     'password' => 'pas$$word@',
                 ],
             ],


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-373

Slack: https://keboola.slack.com/archives/C09U3R1J4/p1596668852020300

Changes:
- `League/Uri` was converting host letters to lowercase (when missing `intl` ext was installed), ....
- ....but VPN hosts contains mixed upper and lower case letters, eg. `aBC1cmVrABc.vpn2keboola.com`, it is now fixed and tested.